### PR TITLE
feat(kopiur): fan out snapshots to a new R2 repository

### DIFF
--- a/kubernetes/apps/default/kopiur-repository-r2/flux-kustomization.yaml
+++ b/kubernetes/apps/default/kopiur-repository-r2/flux-kustomization.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-repository-r2
+spec:
+  dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
+  interval: 12h
+  path: ./kubernetes/apps/default/kopiur-repository-r2/resources
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/kopiur-repository-r2/resources/kustomization.yaml
+++ b/kubernetes/apps/default/kopiur-repository-r2/resources/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./repository.yaml

--- a/kubernetes/apps/default/kopiur-repository-r2/resources/repository.yaml
+++ b/kubernetes/apps/default/kopiur-repository-r2/resources/repository.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/repository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Repository
+metadata:
+  name: archive-r2
+spec:
+  backend:
+    s3:
+      bucket: talos-n150-cluster-kopia-archive
+      region: auto
+      endpoint: d1f0621fbc1ba3f26f44754274430881.r2.cloudflarestorage.com
+      auth:
+        secretRef:
+          name: kopiur-repository
+  encryption:
+    passwordSecretRef:
+      name: kopiur-repository
+      key: KOPIA_PASSWORD
+  create:
+    enabled: true # fresh repository — no filesystem data to adopt on R2

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -12,6 +12,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./kopiur-repository/flux-kustomization.yaml
+  - ./kopiur-repository-r2/flux-kustomization.yaml
   - ./sonarr/flux-kustomization.yaml
   - ./radarr/flux-kustomization.yaml
   - ./listenarr/flux-kustomization.yaml

--- a/kubernetes/components/kopiur/backup/restore.yaml
+++ b/kubernetes/components/kopiur/backup/restore.yaml
@@ -5,6 +5,9 @@ kind: Restore
 metadata:
   name: ${app}
 spec:
+  # Fan-out policies refuse to guess; NFS is the member with real history until R2 fills.
+  repository:
+    name: archive
   source:
     fromPolicy:
       name: ${app}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -5,8 +5,10 @@ kind: SnapshotPolicy
 metadata:
   name: ${app}
 spec:
-  repository:
-    name: archive
+  # Fan-out: one mover Job per (source, repository). Drop `archive` once R2 has proven itself.
+  repositories:
+    - name: archive
+    - name: archive-r2
   # Pins the existing snapshot identity so kopiur continues the adopted history.
   identity:
     hostname: default

--- a/kubernetes/components/kopiur/secret/external-secret.yaml
+++ b/kubernetes/components/kopiur/secret/external-secret.yaml
@@ -7,14 +7,23 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword
+    name: onepassword-vault
   target:
     name: kopiur-repository
     creationPolicy: Owner
     template:
       data:
         KOPIA_PASSWORD: "{{ .credential }}"
+        AWS_ACCESS_KEY_ID: "{{ .accessKeyId }}"
+        # R2 S3 auth wants the SHA-256 of the account token, not the token itself
+        AWS_SECRET_ACCESS_KEY: "{{ .secretAccessKey | sha256sum }}"
   data:
     - secretKey: credential
       remoteRef:
-        key: KOPIA_PASSWORD
+        key: volsync/kopia/KOPIA_PASSWORD # item predates kopiur; same password as the NFS archive repo
+    - secretKey: accessKeyId
+      remoteRef:
+        key: cloudflare/R2/access-key-id
+    - secretKey: secretAccessKey
+      remoteRef:
+        key: cloudflare/R2/secret-access-key # holds the raw cfat_ token; hashed in the template above


### PR DESCRIPTION
Adds `archive-r2`, an S3-backed Repository on Cloudflare R2, and points every
SnapshotPolicy at both it and the existing NFS `archive` via `spec.repositories`.
Fresh repo, no blob-level migration — `keepLatest: 45` rebuilds full retention
depth in about 15 days at the current three-snapshots-a-day cadence.

The fan-out is meant to be temporary. It's there so R2 can be watched filling up
while NFS stays warm, rather than cold. Collapsing back to a single repo is two
edits: the policy's `repositories` back to `repository: archive-r2`, and the
Restore pin flipped or dropped.

## Secrets

The kopiur ExternalSecret moves off the `onepassword` environment store to
`onepassword-vault`, and picks up `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
alongside the existing `KOPIA_PASSWORD`. The vault's copy of the Kopia password
hashes identical to what's running, so the NFS repo stays unlockable.

One wrinkle worth recording: `cloudflare/R2/secret-access-key` in 1Password holds
the raw `cfat_` account token, because that's what the Terraform `local-exec` in
milton-ops writes. R2's S3 endpoint wants the SHA-256 of that token, so the
template hashes it with `sha256sum`. This survives rotation — Terraform writes a
new raw token, ESO re-hashes it.

## Restores

A `fromPolicy` restore against a fan-out policy is refused until it names one
member, since the captures can diverge and kopiur won't guess. The populator
Restores now pin `spec.repository` to `archive`, which is the member with actual
history. Pointing them at an empty R2 while `onMissingSnapshot: Continue` is set
would silently bootstrap blank volumes on any PVC recreated this week.

For the eventual R2 restore drill, use a one-off Restore carrying
`repository: {name: archive-r2}` rather than editing the component.

## Two things that were wrong before this

The Repository CR named bucket `mcf-io-kopia-archive`. The Terraform-managed
bucket is `talos-n150-cluster-kopia-archive` (`cloudflare_r2_bucket.kopia_archive`
in milton-ops `cloudflare/mcf-io.tf`). The old name returns AccessDenied.

The secret access key was the raw token rather than its hash, so every S3 call
would have failed auth.

## Verified

`aws s3 ls` against the corrected bucket with the derived key authenticates and
returns empty, which is what `create.enabled: true` expects. The
`onepassword-vault` ClusterSecretStore is Valid and Ready. `flate build ks`
renders 13 policies each carrying both repositories and 13 Restores pinned to
`archive`. The live SnapshotPolicy CRD already has `spec.repositories`, so the
stale-schema trap in kopiur's upgrade notes doesn't apply. `hk check` clean.

Still unproven: that ESO 2.10.0 exposes sprig's `sha256sum`. The docs say
everything except `env`/`expandenv` is available but don't name it. A missing
function shows up immediately as a `SecretSyncedError` on first reconcile.

## Fan-out costs, for the record

Each slot expands to one Snapshot CR and one mover Job per (source, repository),
reading and uploading the source twice. Retention is per pair, so it's 45 kept in
each rather than 45 split. Child names gain a `-repo-<name>-<hash>` suffix.
`concurrencyPolicy: Forbid` is the schedule default and holds the whole slot, so
if stor01 goes unreachable the next 8-hour slot is skipped for R2 as well —
switch to `Allow` if that becomes annoying.