### PR TITLE
chore(talos): move secrets to milton-ops vault

### DIFF
--- a/talos/cluster.yaml
+++ b/talos/cluster.yaml
@@ -2,9 +2,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.13/website/content/v1.13/schemas/config.schema.json
 version: v1alpha1
 machine:
-  token: op://mcfio/talos-n150-cluster/machine/token
+  token: op://milton-ops/talos-n150-cluster/machine/token
   ca:
-    crt: op://mcfio/talos-n150-cluster/machine/ca_crt
+    crt: op://milton-ops/talos-n150-cluster/machine/ca_crt
   features:
     diskQuotaSupport: true
     hostDNS:
@@ -63,10 +63,10 @@ machine:
     net.core.wmem_max: "67108864" # Cloudflared / QUIC
     user.max_user_namespaces: "65535" # User namespaces
 cluster:
-  id: op://mcfio/talos-n150-cluster/cluster/id
-  secret: op://mcfio/talos-n150-cluster/cluster/secret
+  id: op://milton-ops/talos-n150-cluster/cluster/id
+  secret: op://milton-ops/talos-n150-cluster/cluster/secret
   ca:
-    crt: op://mcfio/talos-n150-cluster/cluster/ca_crt
+    crt: op://milton-ops/talos-n150-cluster/cluster/ca_crt
   controlPlane:
     endpoint: https://k8s.internal:6443
   clusterName: home-cluster
@@ -85,7 +85,7 @@ cluster:
       - 10.45.0.0/16
     serviceSubnets:
       - 10.46.0.0/16
-  token: op://mcfio/talos-n150-cluster/cluster/token
+  token: op://milton-ops/talos-n150-cluster/cluster/token
   proxy:
     disabled: true
     image: registry.k8s.io/kube-proxy:v1.36.4

--- a/talos/controlplane.yaml
+++ b/talos/controlplane.yaml
@@ -3,8 +3,8 @@
 version: v1alpha1
 machine:
   ca:
-    crt: op://mcfio/talos-n150-cluster/machine/ca_crt
-    key: op://mcfio/talos-n150-cluster/machine/ca_key
+    crt: op://milton-ops/talos-n150-cluster/machine/ca_crt
+    key: op://milton-ops/talos-n150-cluster/machine/ca_key
   features:
     kubernetesTalosAPIAccess:
       enabled: true
@@ -14,14 +14,14 @@ machine:
         - system-upgrade
 cluster:
   ca:
-    crt: op://mcfio/talos-n150-cluster/cluster/ca_crt
-    key: op://mcfio/talos-n150-cluster/cluster/ca_key
+    crt: op://milton-ops/talos-n150-cluster/cluster/ca_crt
+    key: op://milton-ops/talos-n150-cluster/cluster/ca_key
   aggregatorCA:
-    crt: op://mcfio/talos-n150-cluster/cluster/aggregator_ca_crt
-    key: op://mcfio/talos-n150-cluster/cluster/aggregator_ca_key
+    crt: op://milton-ops/talos-n150-cluster/cluster/aggregator_ca_crt
+    key: op://milton-ops/talos-n150-cluster/cluster/aggregator_ca_key
   serviceAccount:
-    key: op://mcfio/talos-n150-cluster/cluster/service_account_key
-  secretboxEncryptionSecret: op://mcfio/talos-n150-cluster/cluster/secretbox_encryption_secret
+    key: op://milton-ops/talos-n150-cluster/cluster/service_account_key
+  secretboxEncryptionSecret: op://milton-ops/talos-n150-cluster/cluster/secretbox_encryption_secret
   apiServer:
     image: registry.k8s.io/kube-apiserver:v1.36.4
     extraArgs:
@@ -65,8 +65,8 @@ cluster:
     disabled: true
   etcd:
     ca:
-      crt: op://mcfio/talos-n150-cluster/etcd/ca_crt
-      key: op://mcfio/talos-n150-cluster/etcd/ca_key
+      crt: op://milton-ops/talos-n150-cluster/etcd/ca_crt
+      key: op://milton-ops/talos-n150-cluster/etcd/ca_key
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
       heartbeat-interval: "250"


### PR DESCRIPTION
## Summary

The talos-n150-cluster secrets moved from the mcfio 1Password vault to milton-ops. Updated the `op://mcfio/talos-n150-cluster/...` references in `talos/cluster.yaml` and `talos/controlplane.yaml` to `op://milton-ops/talos-n150-cluster/...`. Item name and field paths are unchanged.

The same rename went directly onto `feat/talos-1.14-multidoc`, which isn't merged yet and carries its own set of these references.