### PR TITLE
fix(default): enforce AllowedHosts on sonarr/radarr/prowlarr, migrate arr secrets to 1Password vault

### DIFF
--- a/kubernetes/apps/default/prowlarr/resources/external-secret.yaml
+++ b/kubernetes/apps/default/prowlarr/resources/external-secret.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword
+    name: onepassword-vault
   target:
     creationPolicy: Owner
   data:
     - secretKey: PROWLARR__AUTH__APIKEY
       remoteRef:
-        key: PROWLARR_API_KEY
+        key: arr-stack/prowlarr/credential

--- a/kubernetes/apps/default/prowlarr/resources/helm-release.yaml
+++ b/kubernetes/apps/default/prowlarr/resources/helm-release.yaml
@@ -27,7 +27,9 @@ spec:
               PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
               PROWLARR__LOG__DBENABLED: "False"
               PROWLARR__LOG__LEVEL: info
+              PROWLARR__SERVER__ALLOWEDHOSTS: prowlarr.milton.mcf.io,prowlarr.default.svc.cluster.local
               PROWLARR__SERVER__PORT: &port 9696
+              PROWLARR__SERVER__TRUSTEDNETWORKS: 10.45.0.0/16
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}"
@@ -39,6 +41,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1

--- a/kubernetes/apps/default/radarr/resources/external-secret.yaml
+++ b/kubernetes/apps/default/radarr/resources/external-secret.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword
+    name: onepassword-vault
   target:
     creationPolicy: Owner
   data:
     - secretKey: RADARR__AUTH__APIKEY
       remoteRef:
-        key: RADARR_API_KEY
+        key: arr-stack/radarr/credential

--- a/kubernetes/apps/default/radarr/resources/helm-release.yaml
+++ b/kubernetes/apps/default/radarr/resources/helm-release.yaml
@@ -27,7 +27,9 @@ spec:
               RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
               RADARR__lOG__DBENABLED: "False"
               RADARR__lOG__LEVEL: info
+              RADARR__SERVER__ALLOWEDHOSTS: radarr.milton.mcf.io,radarr.default.svc.cluster.local
               RADARR__SERVER__PORT: &port 7878
+              RADARR__SERVER__TRUSTEDNETWORKS: 10.45.0.0/16
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}"
@@ -39,6 +41,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   initialDelaySeconds: 10
                   periodSeconds: 10
                   timeoutSeconds: 1

--- a/kubernetes/apps/default/recyclarr/resources/external-secret.yaml
+++ b/kubernetes/apps/default/recyclarr/resources/external-secret.yaml
@@ -7,13 +7,13 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword
+    name: onepassword-vault
   target:
     creationPolicy: Owner
   data:
     - secretKey: RADARR__APIKEY
       remoteRef:
-        key: RADARR_API_KEY
+        key: arr-stack/radarr/credential
     - secretKey: SONARR__APIKEY
       remoteRef:
-        key: SONARR_API_KEY
+        key: arr-stack/sonarr/credential

--- a/kubernetes/apps/default/sonarr/resources/external-secret.yaml
+++ b/kubernetes/apps/default/sonarr/resources/external-secret.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword
+    name: onepassword-vault
   target:
     creationPolicy: Owner
   data:
     - secretKey: SONARR__AUTH__APIKEY
       remoteRef:
-        key: SONARR_API_KEY
+        key: arr-stack/sonarr/credential

--- a/kubernetes/apps/default/sonarr/resources/helm-release.yaml
+++ b/kubernetes/apps/default/sonarr/resources/helm-release.yaml
@@ -27,7 +27,9 @@ spec:
               SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
+              SONARR__SERVER__ALLOWEDHOSTS: sonarr.milton.mcf.io,sonarr.default.svc.cluster.local
               SONARR__SERVER__PORT: &port 8989
+              SONARR__SERVER__TRUSTEDNETWORKS: 10.45.0.0/16
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}"
@@ -39,6 +41,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   initialDelaySeconds: 10
                   periodSeconds: 10
                   timeoutSeconds: 1


### PR DESCRIPTION
## Summary

Sonarr/Sonarr@5f69ab0954 and @22f05a4343 added an `AllowedHostsCheck` that rejects requests whose Host header isn't on an allowlist. Sonarr picked this up in its latest image bump; radarr and prowlarr are on the same underlying check, so I mirrored the fix there manually.

For sonarr, radarr, and prowlarr: set `SERVER__ALLOWEDHOSTS` to each app's ingress hostname plus its in-cluster FQDN, and added `SERVER__TRUSTEDNETWORKS` for the pod CIDR (`10.45.0.0/16`). Also added a `Host: localhost` header to each app's `/ping` liveness probe — kubelet's probe sends no Host header, and the check was rejecting it.

Also moved the sonarr/radarr/prowlarr/recyclarr `ExternalSecret`s off the 1Password environment-backed `onepassword` `ClusterSecretStore` onto `onepassword-vault`, renaming the referenced keys to `arr-stack/<app>/credential`. This follows the earlier cluster-wide move away from 1Password Environments.
