### PR TITLE
Remove PagerDuty ahead of account cancellation

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/resources/alertmanager-config.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/resources/alertmanager-config.yaml
@@ -11,7 +11,7 @@ spec:
       - job
     groupInterval: 10m
     groupWait: 5m
-    receiver: pagerduty
+    receiver: blackhole
     repeatInterval: 12h
     routes:
       - receiver: blackhole
@@ -26,11 +26,6 @@ spec:
         matchers:
           - name: alertname
             value: Watchdog
-            matchType: =
-      - receiver: pagerduty
-        matchers:
-          - name: severity
-            value: critical
             matchType: =
   inhibitRules:
     - equal:
@@ -51,10 +46,3 @@ spec:
         - urlSecret:
             name: alertmanager
             key: hcping_url
-    - name: pagerduty
-      pagerdutyConfigs:
-        - routingKey:
-            name: alertmanager
-            key: pagerduty_routing_key
-          # relies on the PagerDuty service's own urgency-mapping rules for this severity value
-          severity: "{{ .CommonLabels.severity }}"

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/resources/external-secret.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/resources/external-secret.yaml
@@ -11,9 +11,6 @@ spec:
   target:
     creationPolicy: Owner
   data:
-    - secretKey: pagerduty_routing_key
-      remoteRef:
-        key: pagerduty/alertmanager/routing-key
     - secretKey: hcping_url
       remoteRef:
         key: hcping/url


### PR DESCRIPTION
## Summary

PagerDuty's being cancelled. Removed the receiver, its dedicated critical-severity route, and the routing-key secret pull from the alertmanager ExternalSecret. Both the default route and the former critical-severity route now fall through to the existing `blackhole` receiver, so nothing pages until a replacement is wired in — safe to delete the `pagerduty/alertmanager/routing-key` item from 1Password once this merges.