### PR TITLE
Route alerts to Pushover

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/resources/alertmanager-config.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/resources/alertmanager-config.yaml
@@ -48,9 +48,39 @@ spec:
             key: hcping_url
     - name: pushover
       pushoverConfigs:
-        - userKey:
-            name: alertmanager
-            key: pushover_user_key
+        - html: true
+          message: |-
+            {{- range .Alerts }}
+              {{- if ne .Annotations.description "" }}
+                {{ .Annotations.description }}
+              {{- else if ne .Annotations.summary "" }}
+                {{ .Annotations.summary }}
+              {{- else if ne .Annotations.message "" }}
+                {{ .Annotations.message }}
+              {{- else }}
+                Alert description not available
+              {{- end }}
+              {{- if gt (len .Labels.SortedPairs) 0 }}
+                <small>
+                  {{- range .Labels.SortedPairs }}
+                    <b>{{ .Name }}:</b> {{ .Value }}
+                  {{- end }}
+                </small>
+              {{- end }}
+            {{- end }}
+          monospace: false
+          priority: |-
+            {{ if eq .Status "firing" }}1{{ else }}0{{ end }}
+          sendResolved: true
+          sound: gamelan
+          title: >-
+            [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+          ttl: 86400s
           token:
             name: alertmanager
             key: pushover_token
+          userKey:
+            name: alertmanager
+            key: pushover_user_key
+          url: https://alertmanager.milton.mcf.io
+          urlTitle: View in Alertmanager

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/resources/alertmanager-config.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/resources/alertmanager-config.yaml
@@ -11,7 +11,7 @@ spec:
       - job
     groupInterval: 10m
     groupWait: 5m
-    receiver: blackhole
+    receiver: pushover
     repeatInterval: 12h
     routes:
       - receiver: blackhole
@@ -46,3 +46,11 @@ spec:
         - urlSecret:
             name: alertmanager
             key: hcping_url
+    - name: pushover
+      pushoverConfigs:
+        - userKey:
+            name: alertmanager
+            key: pushover_user_key
+          token:
+            name: alertmanager
+            key: pushover_token

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/resources/external-secret.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/resources/external-secret.yaml
@@ -14,3 +14,9 @@ spec:
     - secretKey: hcping_url
       remoteRef:
         key: hcping/url
+    - secretKey: pushover_user_key
+      remoteRef:
+        key: pushover/user_key
+    - secretKey: pushover_token
+      remoteRef:
+        key: pushover/credential


### PR DESCRIPTION
## Summary

Wires the new pushover receiver in as the default route, replacing the temporary blackhole fallback left after removing PagerDuty. Credentials come from the `pushover` item in the `talos-n150-cluster` 1Password vault via the existing `alertmanager` ExternalSecret.