### PR TITLE
Fix smartctl-exporter alerting and instance labels

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/resources/helm-release.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/resources/helm-release.yaml
@@ -101,6 +101,6 @@ spec:
             - action: replace
               sourceLabels:
                 - __meta_kubernetes_pod_node_name
-              targetLabel: nodename
+              targetLabel: instance
     kube-state-metrics:
       fullnameOverride: kube-state-metrics

--- a/kubernetes/apps/monitoring/smartctl-exporter/resources/grafana-dashboard.yaml
+++ b/kubernetes/apps/monitoring/smartctl-exporter/resources/grafana-dashboard.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: smartctl-exporter
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/22604/revisions/3/download

--- a/kubernetes/apps/monitoring/smartctl-exporter/resources/helm-release.yaml
+++ b/kubernetes/apps/monitoring/smartctl-exporter/resources/helm-release.yaml
@@ -38,12 +38,3 @@ spec:
           for: 5m
         smartCTLDInterfaceSlow:
           for: 5m
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                    - amd64

--- a/kubernetes/apps/monitoring/smartctl-exporter/resources/helm-release.yaml
+++ b/kubernetes/apps/monitoring/smartctl-exporter/resources/helm-release.yaml
@@ -20,6 +20,24 @@ spec:
           targetLabel: instance
     prometheusRules:
       enabled: true
+      rules:
+        smartCTLDDeviceTemperature:
+          for: 5m
+          expr: smartctl_device_temperature{temperature_type="current"} > 65
+          annotations:
+            summary: Device has temperature higher than 65°C
+            description: Device {{ $labels.device }} on instance {{ $labels.instance }} has temperature higher than 65°C
+        smartCTLDeviceStatus:
+          for: 5m
+          expr: (smartctl_device_smart_status != 1 or smartctl_device_status != 1)
+        smartCTLDeviceMediaErrors:
+          for: 5m
+        smartCTLDeviceCriticalWarning:
+          for: 5m
+        smartCTLDeviceAvailableSpareUnderThreshold:
+          for: 5m
+        smartCTLDInterfaceSlow:
+          for: 5m
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/apps/monitoring/smartctl-exporter/resources/helm-release.yaml
+++ b/kubernetes/apps/monitoring/smartctl-exporter/resources/helm-release.yaml
@@ -13,6 +13,11 @@ spec:
     fullnameOverride: *appname
     serviceMonitor:
       enabled: true
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: instance
     prometheusRules:
       enabled: true
     affinity:

--- a/kubernetes/apps/monitoring/smartctl-exporter/resources/kustomization.yaml
+++ b/kubernetes/apps/monitoring/smartctl-exporter/resources/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
+  - ./grafana-dashboard.yaml


### PR DESCRIPTION
## Summary
- Relabel `instance` from the raw pod IP:port to the node hostname for node-exporter and smartctl-exporter, so alerts and dashboards actually show which node is affected.
- Raise smartctl-exporter's temperature alert threshold from 60°C to 65°C and widen `for` from 1m to 5m across its rules — 60°C is normal idle temp for these NVMe drives in fanless enclosures, and two were firing on nothing. Also check `smartctl_device_status` alongside `smart_status`. Add the Grafana dashboard for smartctl-exporter, which the chart doesn't ship one for. Thresholds and dashboard borrowed from onedr0p/home-ops.
- Drop the amd64 node affinity on smartctl-exporter — every node in this cluster is amd64.