### PR TITLE
fix(monitoring): raise smartctl NVMe temperature alert to 75°C

### DIFF
--- a/kubernetes/apps/monitoring/smartctl-exporter/resources/helm-release.yaml
+++ b/kubernetes/apps/monitoring/smartctl-exporter/resources/helm-release.yaml
@@ -21,12 +21,14 @@ spec:
     prometheusRules:
       enabled: true
       rules:
+        # 75°C, not the chart's 65 — consumer M.2 in a fanless G3+ idles in the 60s.
+        # SN570 firmware warns at 80°C and throttles from there.
         smartCTLDDeviceTemperature:
-          for: 5m
-          expr: smartctl_device_temperature{temperature_type="current"} > 65
+          for: 30m
+          expr: smartctl_device_temperature{temperature_type="current"} > 75
           annotations:
-            summary: Device has temperature higher than 65°C
-            description: Device {{ $labels.device }} on instance {{ $labels.instance }} has temperature higher than 65°C
+            summary: Device has temperature higher than 75°C
+            description: Device {{ $labels.device }} on instance {{ $labels.instance }} has temperature higher than 75°C
         smartCTLDeviceStatus:
           for: 5m
           expr: (smartctl_device_smart_status != 1 or smartctl_device_status != 1)


### PR DESCRIPTION
## Summary

`smartCTLDDeviceTemperature` inherits the chart default of `> 65` with `for: 5m`, which fires
continuously on talos-node02. Over the last 7 days that drive sat above 65°C about 7% of the
time at a 64°C average, peaking at 73°C.

The temperature is normal for the hardware. All three control-plane nodes run WD Blue SN570
1TB in the fanless G3+ chassis, where the M.2 slot has no real airflow path. The drive's own
firmware sets `Warning Comp. Temp. Threshold: 80°C` and `Critical: 85°C`, and doesn't throttle
until the warning point. node02 is at 18% `percentage_used`, 100% available spare, and zero
media errors, so nothing is degrading — it's just the oldest of the three at 28,624 power-on
hours. NVMe utilization is ~2.4% with 1.7 MB/s average writes, so the heat isn't workload
driven either.

65°C is a sane threshold for a datacentre U.2 drive and too tight for consumer M.2 here. This
raises it to 75°C and stretches `for:` to 30m, so the rule catches sustained heat approaching
the firmware's own warning point rather than normal idle temperature. The real risk with the
current setting is habituation to an alert that never means anything.

Lifetime counters back the 75°C choice: node02 has logged 72 minutes above 80°C and 1 minute
above 85°C across its whole life, node03 has 110 warning-minutes and zero critical. Genuine
excursions are rare and would still trip the new threshold.
